### PR TITLE
Working with mardown v2.3.1, and some updated options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,53 @@ QRCODE Markdown Extension
 1. `python ./setup.py install`
 
 
+## Format
+
+### Traditional Syntax
+
+This is the "traditional" short syntax:
+
+    [-[str data to encode]-]
+
+
+### Domain Syntax
+
+A second, more verbose but more general and powerful syntax, is called the "domain"
+syntax. It looks like this:
+
+    :qr:4:bg=#FF0000:fg=#0000FF:ec=Q:[Encode this as well.]
+
+The domain syntax has the general form:
+
+    :qr:<OPTS>:[<DATA>]
+
+Where OPTS can be used to specify the pixel-size, the foreground and background size,
+and the QR Error Correcting Level to use (L, M, H, or Q). (Note that the foreground
+color doesn't work real well). All OPTS are optional.
+
+## Config Options
+
+intPixelSize
+: Pixel Size of each dark and light bit. _Default is 2_
+
+useShortSyntax
+: Enable the use of the original short syntax. _Default is True_
+
+bgColor
+: The color to use for background ("light colored") bits. _Default is #FFFFFF (white)_
+
+fgColor
+: The color to use for foreground ("dark colored") bits. _Default is #000000 (black)_
+
+ecLevel
+: The error correcting level to use. One of L, M, H, or Q. _Default is L_
+
+
+## Notes
+
+You can try including square brackets in DATA by escaping them with front slashes,
+but markdown seems to be replacing them with some strange escape code.
+
 ## Legal
 
 ### extension.py

--- a/mdx_qrcode/QrCodeLib.py
+++ b/mdx_qrcode/QrCodeLib.py
@@ -284,11 +284,9 @@ class QRCode:
             totalDataCount += rsBlocks[i].dataCount
 
         if (buffer.getLengthInBits() > totalDataCount * 8):
-            raise Exception("code length overflow. ("
-                + buffer.getLengthInBits()
-                + ">"
-                +  totalDataCount * 8
-                + ")")
+            raise Exception("code length overflow. (%d > %d)"
+                % (buffer.getLengthInBits(), totalDataCount * 8)
+            )
 
         #// end code
         if (buffer.getLengthInBits() + 4 <= totalDataCount * 8):

--- a/mdx_qrcode/extension.py
+++ b/mdx_qrcode/extension.py
@@ -18,7 +18,7 @@ QRcode markdown filter
 import markdown
 import StringIO
 from QrCodeLib import *
-from markdown import etree
+from markdown.util import etree
 from base64 import b64encode
 
 class QrCodeExtension(markdown.Extension):
@@ -33,7 +33,6 @@ class QrCodeExtension(markdown.Extension):
     # Set extension defaults
     self.config = {
       "intPixelSize"  : [  2, "Pixel Size of each dark and light bit" ],
-      "intCanvasSize" : [ 10, "Canvas Size of the QRCode" ],
     }
     # Override defaults with user settings
     for key, value in configs:
@@ -61,15 +60,11 @@ class BasicQrCodePattern(markdown.inlinepatterns.Pattern):
     self.config = config
     markdown.inlinepatterns.Pattern.__init__(self, pattern)
 
-  def getCompiledRegExp(self):
-    import re
-    return re.compile(self.pattern)
-
   def handleMatch(self, match):
 
     if match :
 
-      pixel_size = 2
+      pixel_size = self.config['intPixelSize'][0]
       qrcodeSourceData = str(match.group(1))
       qrCodeObject = QRCode(pixel_size, QRErrorCorrectLevel.L)
       qrCodeObject.addData( qrcodeSourceData )
@@ -81,7 +76,7 @@ class BasicQrCodePattern(markdown.inlinepatterns.Pattern):
       qrCodeImage_File = StringIO.StringIO()
       qrCodeImage.save( qrCodeImage_File , format= 'PNG')
 
-      element = markdown.etree.Element('img')
+      element = markdown.util.etree.Element('img')
       element.set("src", "data:image/png;base64,%s" % b64encode( qrCodeImage_File.getvalue()) )
       element.set("title", "qrcode for : %s " % qrcodeSourceData )
 

--- a/mdx_qrcode/extension.py
+++ b/mdx_qrcode/extension.py
@@ -68,6 +68,7 @@ but markdown seems to be replacing them with some strange escape code.
 
 import markdown
 import StringIO
+import types
 from QrCodeLib import *
 from markdown.util import etree
 from base64 import b64encode
@@ -90,12 +91,14 @@ class QrCodeExtension(markdown.Extension):
       "ecLevel" : ["L", "The error correcting level to use. One of L, M, H, or Q."],
     }
     # Override defaults with user settings
-    for key, value in configs:
-      self.setConfig(key, value)
-
+    if configs:
+      for key, value in configs.items():
+        self.setConfig(key, value)
 
     self.config["intPixelSize"][0] = int(self.config["intPixelSize"][0])
-    self.config["useShortSyntax"][0] = (self.config["useShortSyntax"][0]).lower() in ("true", "yes", "t", "y", "1")
+
+    if type(self.config["useShortSyntax"][0]) == types.StringType:
+        self.config["useShortSyntax"][0] = (self.config["useShortSyntax"][0]).lower() in ("true", "yes", "t", "y", "1")
 
 
   def add_inline(self, md, name, pattern_class, pattern):
@@ -177,6 +180,7 @@ class BasicQrCodePattern(markdown.inlinepatterns.Pattern):
       element = markdown.util.etree.Element('img')
       element.set("src", "data:image/png;base64,%s" % b64encode( qrCodeImage_File.getvalue()) )
       element.set("title", "qrcode for : %s " % qrcodeSourceData )
+      element.set("class", "qrcode")
 
       qrCodeImage_File.close()
 


### PR DESCRIPTION
Got this working again for markdown version 2.3.1 (latest code from github and from pypi doesn't work with latest markdown, primarily due to issue #1, but some other minor issues as well).

-Fixed issue #1 (import error): etree is under markdown.util, not just markdown.
-Made use of intPixelSize config.
-Removed unused intCanvasSize config.
-Made use of Pattern's default impl of getCompiledRegExp, which wraps the pattern in some important regex.
-Added alternate syntax which is more general and allows specifying options per use (colors, size, and error correction level).
