### PR TITLE
Fixed ModuleNotFoundError: No module named 'extension'

### DIFF
--- a/mdx_qrcode/extension.py
+++ b/mdx_qrcode/extension.py
@@ -17,7 +17,7 @@ QRcode markdown filter
 
 import markdown
 import StringIO
-from QrCodeLib import *
+from .QrCodeLib import *
 from markdown import etree
 from base64 import b64encode
 


### PR DESCRIPTION
I actually experienced this issue:
![image](https://user-images.githubusercontent.com/50262917/94292005-ff71df80-ff79-11ea-97b9-090029d09223.png)
